### PR TITLE
CI: Fix coverage upload and pip caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ env:
 
 jobs:
   test:
+    name: test w/ Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         if: always()
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - uses: actions/setup-python@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            dev-requirements.txt
+            requirements.txt
+
       - name: Install dependencies
         run: |
           python3 -m pip install coverage
           python3 -m pip install -U -r dev-requirements.txt
+
       - name: Tests
         run: |
           python3 -m coverage run --branch -m pytest tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,12 @@
 name: Tests
 
-on:
-  pull_request:
-  push:
-    branches: main
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:
-    name: test w/ Python ${{ matrix.python-version }}
-
     runs-on: ubuntu-latest
-
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
 
@@ -26,13 +21,16 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python3 -m pip install coverage
-      - run: python3 -m pip install -U -r dev-requirements.txt
-      - run: python3 -m coverage run --branch -m pytest tests/
-      - uses: codecov/codecov-action@v3
+      - name: Install dependencies
+        run: |
+          python3 -m pip install coverage
+          python3 -m pip install -U -r dev-requirements.txt
+      - name: Tests
+        run: |
+          python3 -m coverage run --branch -m pytest tests/
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-    
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,20 +16,20 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - run: python3 -m pip install coverage
       - run: python3 -m pip install -U -r dev-requirements.txt
       - run: python3 -m coverage run --branch -m pytest tests/
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python3 -m pip install coverage
           python3 -m pip install -U -r dev-requirements.txt
 
       - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Tests
         run: |
           python3 -m coverage run --branch -m pytest tests/
+          python3 -m coverage xml
+
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Tests
         run: |
           python3 -m coverage run --branch -m pytest tests/
+          python3 -m coverage report
           python3 -m coverage xml
 
       - name: Upload coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Byte-compiled / optimized / DLL files
+__pycache__
+
+# Unit test / coverage reports
+htmlcov/
+coverage.xml
+
 # virtualenv
 venv/
 ENV/


### PR DESCRIPTION
There's been no coverage uploaded to Codecov for about two years:

https://app.codecov.io/gh/python/blurb_it/commits

We need to generate the `coverage.xml` file to be uploaded: `python3 -m coverage xml`

Also:

- The latest release of https://github.com/codecov/codecov-action supports tokenless upload from GHA
- Bump GitHub Actions
- Coverage is installed in `dev-requirements.txt`, don't need to install twice
- Use actions/setup-python's [built-in caching](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages) to simplify and fix caching
  - it was earlier using the same cache for all Python versions, so 3.12 was rebuilding sdists every time because <=3.11 have wheels
  - point to both our `*requirements.txt` for the cache dependency key rather than non-existent `pyproject.toml` - when these change the cache will now be invalidated
- Group steps and update config
- Add colour to CI for readability
- gitignore some test output
