### PR TITLE
Dependabot: switch to monthly frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: sentry-sdk


### PR DESCRIPTION
Monthly means things don't get too out of date, and will be less noisy.

Docs:

* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#frequency-of-dependabot-pull-requests

See also:
 
* https://github.com/python/bedevere/pull/497
* https://github.com/python/devguide/pull/922
* https://github.com/python/miss-islington/pull/573
* https://github.com/python/cherry-picker/pull/22
