### PR TITLE
Use underscores instead of spaces in paths

### DIFF
--- a/blurb_it/util.py
+++ b/blurb_it/util.py
@@ -9,6 +9,8 @@ from blurb_it import error
 
 
 async def get_misc_news_filename(issue_number, section, body):
+    if " " in section:
+        raise ValueError(f"Use hyphens not spaces in section name: {section}")
     date = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
     nonce = await nonceify(body)
     path = f"Misc/NEWS.d/next/{section}/{date}.gh-issue-{issue_number}.{nonce}.rst"

--- a/blurb_it/util.py
+++ b/blurb_it/util.py
@@ -10,7 +10,7 @@ from blurb_it import error
 
 async def get_misc_news_filename(issue_number, section, body):
     if " " in section:
-        raise ValueError(f"Use hyphens not spaces in section name: {section}")
+        raise ValueError(f"Use underscores not spaces in section name: {section}")
     date = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
     nonce = await nonceify(body)
     path = f"Misc/NEWS.d/next/{section}/{date}.gh-issue-{issue_number}.{nonce}.rst"

--- a/templates/add_blurb.html
+++ b/templates/add_blurb.html
@@ -46,7 +46,7 @@
                             <option>Windows</option>
                             <option>macOS</option>
                             <option>IDLE</option>
-                            <option>Tools-Demos</option>
+                            <option value="Tools-Demos">Tools and Demos</option>
                             <option value="C_API">C API</option>
                         </select>
                     </div>

--- a/templates/add_blurb.html
+++ b/templates/add_blurb.html
@@ -38,7 +38,7 @@
                         <select id="section" name="section" class="form-control form-inline" required>
                             <option></option>
                             <option>Security</option>
-                            <option>Core_and_Builtins</option>
+                            <option value="Core_and_Builtins">Core and Builtins</option>
                             <option>Library</option>
                             <option>Documentation</option>
                             <option>Tests</option>
@@ -47,7 +47,7 @@
                             <option>macOS</option>
                             <option>IDLE</option>
                             <option>Tools-Demos</option>
-                            <option>C_API</option>
+                            <option value="C_API">C API</option>
                         </select>
                     </div>
                 </div>

--- a/templates/add_blurb.html
+++ b/templates/add_blurb.html
@@ -38,7 +38,7 @@
                         <select id="section" name="section" class="form-control form-inline" required>
                             <option></option>
                             <option>Security</option>
-                            <option>Core-and-Builtins</option>
+                            <option>Core_and_Builtins</option>
                             <option>Library</option>
                             <option>Documentation</option>
                             <option>Tests</option>
@@ -47,7 +47,7 @@
                             <option>macOS</option>
                             <option>IDLE</option>
                             <option>Tools-Demos</option>
-                            <option>C-API</option>
+                            <option>C_API</option>
                         </select>
                     </div>
                 </div>

--- a/templates/add_blurb.html
+++ b/templates/add_blurb.html
@@ -38,7 +38,7 @@
                         <select id="section" name="section" class="form-control form-inline" required>
                             <option></option>
                             <option>Security</option>
-                            <option>Core and Builtins</option>
+                            <option>Core-and-Builtins</option>
                             <option>Library</option>
                             <option>Documentation</option>
                             <option>Tests</option>
@@ -47,7 +47,7 @@
                             <option>macOS</option>
                             <option>IDLE</option>
                             <option>Tools-Demos</option>
-                            <option>C API</option>
+                            <option>C-API</option>
                         </select>
                     </div>
                 </div>

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -57,6 +57,27 @@ async def test_get_misc_news_filename():
     assert path.endswith(".gh-issue-123.Ps4kgC.rst")
 
 
+async def test_get_misc_news_filename_sections_with_dashes():
+    path = await util.get_misc_news_filename(
+        issue_number=123,
+        section="Core-and-Builtins",
+        body="Lorem ipsum dolor amet flannel squid normcore tbh raclette enim",
+    )
+
+    assert path.startswith("Misc/NEWS.d/next/Core-and-Builtins/")
+
+
+async def test_get_misc_news_filename_sections_with_space():
+    with pytest.raises(
+        ValueError, match="Use hyphens not spaces in section name: Core and Builtins"
+    ):
+        path = await util.get_misc_news_filename(
+            issue_number=123,
+            section="Core and Builtins",
+            body="Lorem ipsum dolor amet flannel squid normcore tbh raclette enim",
+        )
+
+
 async def test_has_session():
     request = mock_request_session()
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -64,7 +64,7 @@ async def test_get_misc_news_filename_sections_with_dashes():
         body="Lorem ipsum dolor amet flannel squid normcore tbh raclette enim",
     )
 
-    assert path.startswith("Misc/NEWS.d/next/Core-and-Builtins/")
+    assert path.startswith("Misc/NEWS.d/next/Core_and_Builtins/")
 
 
 async def test_get_misc_news_filename_sections_with_space():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -60,7 +60,7 @@ async def test_get_misc_news_filename():
 async def test_get_misc_news_filename_sections_with_dashes():
     path = await util.get_misc_news_filename(
         issue_number=123,
-        section="Core-and-Builtins",
+        section="Core_and_Builtins",
         body="Lorem ipsum dolor amet flannel squid normcore tbh raclette enim",
     )
 
@@ -69,9 +69,10 @@ async def test_get_misc_news_filename_sections_with_dashes():
 
 async def test_get_misc_news_filename_sections_with_space():
     with pytest.raises(
-        ValueError, match="Use hyphens not spaces in section name: Core and Builtins"
+        ValueError,
+        match="Use underscores not spaces in section name: Core and Builtins",
     ):
-        path = await util.get_misc_news_filename(
+        await util.get_misc_news_filename(
             issue_number=123,
             section="Core and Builtins",
             body="Lorem ipsum dolor amet flannel squid normcore tbh raclette enim",


### PR DESCRIPTION
For https://github.com/python/core-workflow/issues/186.

Companion to https://github.com/python/core-workflow/pull/499.

I've not tested this other than running the unit tests.

I think this is all we need for blurb-it? For example, there's already "Tools-Demos" with no "/".