### PR TITLE
Add tox.ini to easily test multiple Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
       - name: Tests
         run: |
           tox -e py
-          python3 -m coverage report
-          python3 -m coverage xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,17 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
+            .github/workflows/ci.yml
             dev-requirements.txt
             requirements.txt
 
       - name: Install dependencies
         run: |
-          python3 -m pip install -U -r dev-requirements.txt
+          python3 -m pip install -U coverage tox
 
       - name: Tests
         run: |
-          python3 -m coverage run --branch -m pytest tests/
+          tox -e py
           python3 -m coverage report
           python3 -m coverage xml
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,12 @@
 [pytest]
-addopts = --strict-config --strict-markers
+addopts =
+    --strict-config
+    --strict-markers
+    --cov blurb_it
+    --cov tests
+    --cov-report html
+    --cov-report term
+    --cov-report xml
 xfail_strict = True
 asyncio_mode = auto
 filterwarnings = error

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,4 @@ pass_env =
 commands_pre =
     {envpython} -m pip install -U -r dev-requirements.txt
 commands =
-    {envpython} -m pytest \
-      {posargs}
+    {envpython} -m pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+requires =
+    tox>=4.2
+env_list =
+    py{311, 310, 39, 38}
+
+[testenv]
+pass_env =
+    FORCE_COLOR
+commands_pre =
+    {envpython} -m pip install -U -r dev-requirements.txt
+commands =
+    {envpython} -m coverage run --branch -m pytest tests/ {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4.2
 env_list =
-    py{311, 310, 39, 38}
+    py{312, 311, 310, 39, 38}
 
 [testenv]
 pass_env =

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ pass_env =
 commands_pre =
     {envpython} -m pip install -U -r dev-requirements.txt
 commands =
-    {envpython} -m coverage run --branch -m pytest tests/ {posargs}
+    {envpython} -m pytest --cov blurb_it --cov tests --cov-branch --cov-report html --cov-report term --cov-report xml {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,4 @@ commands_pre =
     {envpython} -m pip install -U -r dev-requirements.txt
 commands =
     {envpython} -m pytest \
-      --cov blurb_it \
-      --cov tests \
-      --cov-report html \
-      --cov-report term \
-      --cov-report xml \
       {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,10 @@ pass_env =
 commands_pre =
     {envpython} -m pip install -U -r dev-requirements.txt
 commands =
-    {envpython} -m pytest --cov blurb_it --cov tests --cov-branch --cov-report html --cov-report term --cov-report xml {posargs}
+    {envpython} -m pytest \
+      --cov blurb_it \
+      --cov tests \
+      --cov-report html \
+      --cov-report term \
+      --cov-report xml \
+      {posargs}


### PR DESCRIPTION
Makes it easier to test locally. Also use it in GitHub Actions, this means the `tox.ini` file itself is tested.

Some example commands:

```sh
# Run on all Python versions listed in the tox file
# Missing versions are skipped
tox

# Run all in parallel (faster)
tox -p auto

# Run on a single Python version
tox -e py311

# Run on multiple Python versions
tox -e py38,py311
```

I left Python 3.12 out for now, because we can't yet test against the betas (https://github.com/python/blurb_it/pull/330#issuecomment-1449496275) and if we include it, then plain `tox` will try and run it and fail. We can still test on demand with `tox -e py312`.

I also formatted `tox.ini` using https://github.com/tox-dev/tox-ini-fmt (we could add that to a pre-commit hook).