### PR TITLE
Temporarily remove `3.12` from the `python-version` list in CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO replace 3.12.0-alpha.4 with 3.12-dev when
-        # aiohttp, frozenlist and yarl support alpha 5+
+        # TODO: add back 3.12 when the aiohttp issue is fixed, see
         # https://github.com/python/blurb_it/pull/330#issuecomment-1449496275
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # and https://github.com/aio-libs/aiohttp/issues/7229
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         # TODO replace 3.12.0-alpha.4 with 3.12-dev when
         # aiohttp, frozenlist and yarl support alpha 5+
         # https://github.com/python/blurb_it/pull/330#issuecomment-1449496275
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.0-alpha.4"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: |
             dev-requirements.txt


### PR DESCRIPTION
This is an attempt to fix the CI failures that are blocking other PRs.

#348 and #349 are failing with:
```
TypeError: rmtree() got an unexpected keyword argument 'onexc'
```
and `onexc` was introduced in `3.12`, but possibly after the alpha that is currently pinned.

However bumping it to `3.12` will probably cause other issues (like the ones seen in #330), so this is just an attempt to see if it works, and if not I'm planning to just remove `3.12` altogether for the time being.