### PR TITLE
Add `3.12` to the `python-version` list in CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: add back 3.12 when the aiohttp issue is fixed, see
-        # https://github.com/python/blurb_it/pull/330#issuecomment-1449496275
-        # and https://github.com/aio-libs/aiohttp/issues/7229
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.4
+aiohttp==3.9.0b0
 aiohttp-jinja2==1.5.1
 gidgethub==5.3.0
 aiohttp-session[secure]==2.12.0


### PR DESCRIPTION
This is a follow-up of #350 that adds back `3.12` to the `python-version` list.
It should be merged once the following issue is fixed:
- [x] https://github.com/aio-libs/aiohttp/issues/7229
- [ ] wait for a new release of `aiohttp` (`>=3.8.6`)