### PR TITLE
Add pytest-asyncio as a dev requirement so we don't skip so many tests in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
+branch = True
 dynamic_context = test_function

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Tests
         run: |
-          python3 -m coverage run --branch -m pytest tests/
+          python3 -m coverage run -m pytest
           python3 -m coverage report
           python3 -m coverage xml
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 coverage==7.3.1
 pytest==7.4.2
+pytest-asyncio==0.21.1
 pytest-aiohttp==1.0.5
 pytest-mock==3.11.1
 pytest-cov==4.1.0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts = --strict-config --strict-markers
+xfail_strict = True
+asyncio_mode = auto
+filterwarnings = error
+testpaths =
+    tests


### PR DESCRIPTION
Currently, all `async def` test functions are being skipped: see the CI runs in https://github.com/python/blurb_it/actions/runs/6453980405/job/17518591042 for an example. With `pytest-asyncio` installed, these are no longer skipped!

We also need to add `asyncio_mode=auto` to the pytest config in order for this plugin to do its job, which necessitated adding a pytest config. So I did that as well, and enhanced the coveragepy config while I was about it.