### PR TITLE
Group dependabot updates, and update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
+    assignees:
+      - "ezio-melotti"
     groups:
       pip:
         patterns:
@@ -26,6 +28,8 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    assignees:
+      - "ezio-melotti"
     groups:
       actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
-  open-pull-requests-limit: 10
+    groups:
+      pip:
+        patterns:
+          - "*"
   ignore:
   - dependency-name: sentry-sdk
     versions:
@@ -18,3 +21,12 @@ updates:
   - dependency-name: pytest
     versions:
     - 6.2.2
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Manage GitHub Actions updates via dependabot.

And open one grouped PR per month instead of many, to help deal with notification fatigue. 

Compare first two repos with the last:

<img width="1185" alt="image" src="https://github.com/python/bedevere/assets/1324225/c587ff53-85a9-4b2f-b20c-003ea127274b">
