### PR TITLE
Test Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/readme.rst
+++ b/readme.rst
@@ -53,7 +53,7 @@ Deploy
 Requirements and dependencies
 =============================
 
-- Python 3.7+
+- Python 3.8+
 - aiohttp
 - aiohttp-jinja2
 - gidgethub >= 5.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4.2
 env_list =
-    py{312, 311, 310, 39, 38}
+    py{313, 312, 311, 310, 39, 38}
 
 [testenv]
 pass_env =


### PR DESCRIPTION
Pending CFFI support for 3.13, should be available in CFFI 1.17.0 soonish:

* https://github.com/python-cffi/cffi/issues/105