### PR TITLE
Fix pytest-cov warning after upgrading to 6.0.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,2 @@
 [run]
 branch = True
-dynamic_context = test_function

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
-coverage==7.6.1
+coverage==7.6.4
 pytest==8.3.3
 pytest-asyncio==0.24.0
 pytest-aiohttp==1.0.5
 pytest-mock==3.14.0
-pytest-cov==5.0.0
+pytest-cov==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-aiohttp==3.10.8
+aiohttp==3.10.10
 aiohttp-jinja2==1.6
 gidgethub==5.3.0
 aiohttp-session[secure]==2.12.1
-sentry-sdk==2.14.0
+sentry-sdk==2.17.0


### PR DESCRIPTION
This is an attempt to fix the following warning seen in #405:
```
     warnings.warn(CentralCovContextWarning(message), stacklevel=1)
 pytest_cov.CentralCovContextWarning: Detected dynamic_context=test_function
 in coverage configuration. This is unnecessary as this plugin provides the
 more complete --cov-context option.
```