### PR TITLE
Restrict input to numbers with a maximum length of six digits

### DIFF
--- a/templates/add_blurb.html
+++ b/templates/add_blurb.html
@@ -18,7 +18,7 @@
                 <input type="hidden" name="csrf" value="{{ csrf }}">
                 <div class="mb-3">
                     <div class="col form-inline">
-                        <label for="issue_number" class="form-inline">GH Issue #</label><input type="text" class="form-control form-inline" placeholder="12345" id="issue_number" name="issue_number" required>
+                        <label for="issue_number" class="form-inline">GH Issue #</label><input type="text" class="form-control form-inline" pattern="^\d{1,6}$" maxlength="6" placeholder="12345" id="issue_number" name="issue_number" required>
                     </div>
                     <div class="col form-inline">
                         <small id="issue_number-help" class="form-text text-muted">The CPython GitHub issue number.</small>
@@ -26,7 +26,7 @@
                 </div>
                 <div class="mb-3">
                     <div class="col form-inline">
-                        <label for="pr_number" class="form-inline">GH Pull Request #</label><input type="text" class="form-control form-inline" placeholder="12345" id="pr_number" name="pr_number" required>
+                        <label for="pr_number" class="form-inline">GH Pull Request #</label><input type="text" class="form-control form-inline" pattern="^\d{1,6}$" maxlength="6" placeholder="12345" id="pr_number" name="pr_number" required>
                     </div>
                     <div class="col form-inline">
                         <small id="gh-help" class="form-text text-muted">The CPython GitHub pull request number.</small>


### PR DESCRIPTION
Now you get the friendly message:

![image](https://github.com/user-attachments/assets/24f79168-fb68-48e5-bd86-31773792272e)

I don't know of a way to change it, but I feel the help text:

> issue number

is pretty clear.

(Something broke and I could not screen record... or maybe I could and my viewer just decided it doesn't like it, who knows...?)