### PR TITLE
Refactor repeated context setup into util.get_app_context()

### DIFF
--- a/blurb_it/__main__.py
+++ b/blurb_it/__main__.py
@@ -31,9 +31,7 @@ async def handle_get(request: Request) -> Response:
     # data = request.query_string
     # data2 = await request.rel_url.query['']
     request_session = await get_session(request)
-    context = {}
-    context["client_id"] = os.environ.get("GH_CLIENT_ID")
-    context["app_url"] = os.environ.get("APP_URL")
+    context = util.get_app_context()
     if request_session.get("username") and request_session.get("token"):
         context["username"] = request_session["username"]
         location = request.app.router["add_blurb"].url_for()
@@ -48,9 +46,7 @@ async def handle_get(request: Request) -> Response:
 @routes.get("/howto", name="howto")
 async def handle_howto_get(request: Request) -> Response:
     """Render a page explaining how to use blurb_it"""
-    context = {}
-    context["client_id"] = os.environ.get("GH_CLIENT_ID")
-    context["app_url"] = os.environ.get("APP_URL")
+    context = util.get_app_context()
     response = aiohttp_jinja2.render_template("howto.html", request, context=context)
     return response
 
@@ -60,9 +56,7 @@ async def handle_install(request: Request) -> Response:
     """Render a page, ask user to install blurb_it"""
     # data = request.query_string
     # data2 = await request.rel_url.query['']
-    context = {}
-    context["client_id"] = os.environ.get("GH_CLIENT_ID")
-    context["app_url"] = os.environ.get("APP_URL")
+    context = util.get_app_context()
     if await util.has_session(request):
         context.update(await util.get_session_context(request, context))
 

--- a/blurb_it/util.py
+++ b/blurb_it/util.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import os
 import time
 import secrets
 
@@ -20,6 +21,14 @@ async def get_misc_news_filename(issue_number, section, body):
 async def nonceify(body):
     digest = hashlib.md5(body.encode("utf-8")).digest()
     return base64.urlsafe_b64encode(digest)[0:6].decode("ascii")
+
+
+def get_app_context() -> dict:
+    return {
+        "client_id": os.environ.get("GH_CLIENT_ID"),
+        "app_url": os.environ.get("APP_URL"),
+        "app_protocol": os.environ.get("APP_PROTOCOL", "https"),
+    }
 
 
 async def get_session_context(request, context=None):

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,7 @@
             <h5 class="my-0 mr-md-auto font-weight-normal"><a href="/">📜🤖 Blurb it!</a></h5>
             <h5 class="my-0 mr-md-auto font-weight-normal"><a href="/howto">How do I use Blurb It?</a></h5>
             {% if not username %}
-                <a class="btn btn-outline-primary btn-social btn-github" href="https://github.com/login/oauth/authorize?client_id={{ client_id }}&scope=repo&redirect_uri=https://{{ app_url }}/add_blurb">
+                <a class="btn btn-outline-primary btn-social btn-github" href="https://github.com/login/oauth/authorize?client_id={{ client_id }}&scope=repo&redirect_uri={{ app_protocol }}://{{ app_url }}/add_blurb">
             <span class="fa fa-github"></span>
             Sign in with GitHub
             </a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
     </div>
 
     <p class="lead text-center">
-        <a class="btn btn-social btn-github" href="https://github.com/login/oauth/authorize?client_id={{ client_id }}&scope=repo&redirect_uri=https://{{ app_url }}/add_blurb">
+        <a class="btn btn-social btn-github" href="https://github.com/login/oauth/authorize?client_id={{ client_id }}&scope=repo&redirect_uri={{ app_protocol }}://{{ app_url }}/add_blurb">
         <span class="fa fa-github"></span>
         Sign in with GitHub
         </a>

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -23,6 +23,24 @@ class FakeGH:
             yield item
 
 
+def test_get_app_context(monkeypatch):
+    monkeypatch.setenv("GH_CLIENT_ID", "test_client_id")
+    monkeypatch.setenv("APP_URL", "localhost:8080")
+    monkeypatch.setenv("APP_PROTOCOL", "http")
+    ctx = util.get_app_context()
+    assert ctx == {
+        "client_id": "test_client_id",
+        "app_url": "localhost:8080",
+        "app_protocol": "http",
+    }
+
+
+def test_get_app_context_defaults_to_https(monkeypatch):
+    monkeypatch.delenv("APP_PROTOCOL", raising=False)
+    ctx = util.get_app_context()
+    assert ctx["app_protocol"] == "https"
+
+
 async def test_nonceify():
     body = (
         "Lorem ipsum dolor amet flannel squid normcore tbh raclette enim"


### PR DESCRIPTION
Working on #422: Refactor to make localhost non-https development/running easier

Three route handlers each built the same client_id/app_url context dict. Extracting to a helper also adds APP_PROTOCOL support so the GitHub OAuth redirect URL works over http:// for local development.