### PR TITLE
Fix links to adding NEWS entry

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -19,7 +19,7 @@ About
 `CPython <https://github.com/python/cpython>`_ pull request.
 
 A ``Misc/NEWS.d`` file `is needed
-<https://devguide.python.org/core-developers/committing/index.html#updating-news-and-what-s-new-in-python>`_
+<https://devguide.python.org/getting-started/pull-request-lifecycle/#news-entry>`_
 for almost all non-trivial changes to CPython.
 
 To use blurb-it, you must be logged in to GitHub.

--- a/templates/add_blurb.html
+++ b/templates/add_blurb.html
@@ -59,7 +59,7 @@ Don't start with '- Issue #<n>: ' or '- gh-issue-<n>: ' or that sort of stuff." 
                 <button type="submit" class="btn btn-primary mb-2">📜🤖 blurb it!</button>
             </form>
         </div>
-        <div class="col-md-12">Alternatively, you can use <a href="https://devguide.python.org/committing/#what-s-new-and-news-entries">blurb on the command line</a>.</div>
+        <div class="col-md-12">Alternatively, you can use <a href="https://devguide.python.org/getting-started/pull-request-lifecycle/#news-entry">blurb on the command line</a>.</div>
     </div>
 
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
     <div class="pricing-header px-3 py-3 pt-md-5 pb-md-4 mx-auto text-center">
         <a href="/"><img class="mb-4" src="https://www.python.org/static/community_logos/python-logo-master-v3-TM.png" alt="" height="72"></a>
         <h1 class="display-4">📜🤖 Blurb it!</h1>
-        <p class="lead"><a href="https://devguide.python.org/committing/#what-s-new-and-news-entries">add a blurb</a> to CPython pull request.</p>
+        <p class="lead"><a href="https://devguide.python.org/getting-started/pull-request-lifecycle/#news-entry">add a blurb</a> to CPython pull request.</p>
     </div>
 
     <p class="lead text-center">


### PR DESCRIPTION
Follow on from https://github.com/python/devguide/pull/1819 which moved this content.